### PR TITLE
0.5.3 - Hijack request's response

### DIFF
--- a/configs/application.yaml
+++ b/configs/application.yaml
@@ -1,6 +1,6 @@
 name: InfiniteMITM
 description: A MITM (man-in-the-middle) CLI for Halo Infinite
-version: 0.5.2
+version: 0.5.3
 author: Alexis Bize
 repository: https://github.com/Alexis-Bize/InfiniteMITM
 proxy:

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gookit/event v1.1.2
 	github.com/ncruces/zenity v0.10.12
+	github.com/prometheus-community/pro-bing v0.4.0
 	golang.org/x/sys v0.21.0
 	golang.org/x/term v0.21.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -46,6 +47,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/image v0.18.0 // indirect
+	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/ncruces/zenity v0.10.12 h1:o4SErDa0kQijlqG6W4OYYzO6kA0fGu34uegvJGcMLB
 github.com/ncruces/zenity v0.10.12/go.mod h1:5OZIERViRR2fN0FcJCcisqxI+lYMDGzEDCEwB/+8iao=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus-community/pro-bing v0.4.0 h1:YMbv+i08gQz97OZZBwLyvmmQEEzyfyrrjEaAchdy3R4=
+github.com/prometheus-community/pro-bing v0.4.0/go.mod h1:b7wRYZtCcPmt4Sz319BykUU241rWLe1VFXyiyWK/dH4=
 github.com/randall77/makefat v0.0.0-20210315173500-7ddd0e42c844 h1:GranzK4hv1/pqTIhMTXt2X8MmMOuH3hMeUR0o9SP5yc=
 github.com/randall77/makefat v0.0.0-20210315173500-7ddd0e42c844/go.mod h1:T1TLSfyWVBRXVGzWd0o9BI4kfoO9InEgfQe4NV3mLz8=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -90,6 +92,8 @@ golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZ
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.18.0 h1:jGzIakQa/ZXI1I0Fxvaa9W7yP25TqT6cHIHn+6CqvSQ=
 golang.org/x/image v0.18.0/go.mod h1:4yyo5vMFQjVjUcVk4jEQcU9MGy/rulF5WvUILseCM2E=
+golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
+golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/application/services/mitm/client.go
+++ b/internal/application/services/mitm/client.go
@@ -118,7 +118,8 @@ func processNodes(contentList []domains.YAMLDomainNode, domain domains.DomainTyp
 		overrideResponse := hijackResponse || len(v.Response.Headers) != 0 || len(v.Response.Before.Commands) != 0 || v.Response.StatusCode != 0
 
 		if hijackResponse {
-			clientRequestHandlers = append(clientRequestHandlers, * createRequestHandler(domain, v, createResponseHandler(domain, v)))
+			clientRequestHandlers = append(clientRequestHandlers, *createRequestHandler(domain, v, createResponseHandler(domain, v)))
+			activeRespHandlers++
 		} else if overrideResponse {
 			clientResponseHandlers = append(clientResponseHandlers, *createResponseHandler(domain, v))
 			activeRespHandlers++
@@ -147,7 +148,10 @@ func createRequestHandler(domain domains.DomainType, node domains.YAMLDomainNode
 				return req, nil
 			}
 
-			pr := proxified.(map[string]bool)
+			pr := proxified.(map[string]bool); if pr["resp"] {
+				return req, nil
+			}
+
 			pr["req"] = true
 			customCtx.SetUserData(context.ProxyKey, pr)
 
@@ -211,7 +215,10 @@ func createResponseHandler(domain domains.DomainType, node domains.YAMLDomainNod
 				return resp
 			}
 
-			pr := proxified.(map[string]bool)
+			pr := proxified.(map[string]bool); if pr["resp"] {
+				return resp
+			}
+
 			pr["resp"] = true
 			customCtx.SetUserData(context.ProxyKey, pr)
 

--- a/internal/application/services/mitm/client.go
+++ b/internal/application/services/mitm/client.go
@@ -90,93 +90,113 @@ func CreateClientMITMHandlers(yaml mitm.YAML) ([]handlers.RequestHandlerStruct, 
 	var clientRequestHandlers []handlers.RequestHandlerStruct
 	var clientResponseHandlers []handlers.ResponseHandlerStruct
 
-	var totalReqProxy int
-	var totalRespProxy int
+	var totalActiveReqHandlers int
+	var totalActiveRespHandlers int
 
 	for _, pair := range domains.GetYAMLContentDomainPairs(yaml.Domains) {
-		reqHandlers, respHandlers, reqTotal, respTotal := processNodes(pair.Content, pair.Domain)
+		reqHandlers, respHandlers, activeReqHandlers, activeRespHandlers := processNodes(pair.Content, pair.Domain)
 		clientRequestHandlers = append(clientRequestHandlers, reqHandlers...)
 		clientResponseHandlers = append(clientResponseHandlers, respHandlers...)
 
-		totalReqProxy += reqTotal
-		totalRespProxy += respTotal
+		totalActiveReqHandlers += activeReqHandlers
+		totalActiveRespHandlers += activeRespHandlers
 	}
 
-	return clientRequestHandlers, clientResponseHandlers, totalReqProxy, totalRespProxy
+	return clientRequestHandlers, clientResponseHandlers, totalActiveReqHandlers, totalActiveRespHandlers
 }
 
 func processNodes(contentList []domains.YAMLDomainNode, domain domains.DomainType) ([]handlers.RequestHandlerStruct, []handlers.ResponseHandlerStruct, int, int) {
 	var clientRequestHandlers []handlers.RequestHandlerStruct
 	var clientResponseHandlers []handlers.ResponseHandlerStruct
 
-	var totalReqProxy int
-	var totalRespProxy int
+	var activeReqHandlers int
+	var activeRespHandlers int
 
 	for _, v := range contentList {
-		isRequestProfixied := v.Request.Body != "" || len(v.Request.Headers) != 0 || len(v.Request.Before.Commands) != 0
-		isResponseProxified := v.Response.Body != "" || len(v.Response.Headers) != 0 || len(v.Response.Before.Commands) != 0 || v.Response.StatusCode != 0
+		var requestHandler *handlers.RequestHandlerStruct
+		var responseHandler *handlers.ResponseHandlerStruct
+		hijackResponse := v.Response.Body != ""
 
-		clientRequestHandlers = append(clientRequestHandlers, createRequestHandler(domain, v, isRequestProfixied, isResponseProxified))
-		clientResponseHandlers = append(clientResponseHandlers, createResponseHandler(domain, v, isRequestProfixied, isResponseProxified))
+		overrideRequest := v.Request.Body != "" || len(v.Request.Headers) != 0 || len(v.Request.Before.Commands) != 0
+		overrideResponse := hijackResponse || len(v.Response.Headers) != 0 || len(v.Response.Before.Commands) != 0 || v.Response.StatusCode != 0
 
-		if isRequestProfixied {
-			totalReqProxy += 1
+		if overrideResponse {
+			responseHandler = createResponseHandler(domain, v)
+			clientResponseHandlers = append(clientResponseHandlers, *responseHandler)
+			activeRespHandlers++
 		}
 
-		if isResponseProxified {
-			totalRespProxy += 1
+		if hijackResponse {
+			requestHandler = createRequestHandler(domain, v, responseHandler)
+			clientRequestHandlers = append(clientRequestHandlers, *requestHandler)
+			continue
+		}
+
+		if overrideRequest {
+			requestHandler = createRequestHandler(domain, v, nil)
+			clientRequestHandlers = append(clientRequestHandlers, *requestHandler)
+			activeReqHandlers++
 		}
 	}
 
-	return clientRequestHandlers, clientResponseHandlers, totalReqProxy, totalRespProxy
+	return clientRequestHandlers, clientResponseHandlers, activeReqHandlers, activeRespHandlers
 }
 
-func createRequestHandler(domain domains.DomainType, node domains.YAMLDomainNode, isRequestProfixied bool, isResponseProxified bool) handlers.RequestHandlerStruct {
+func createRequestHandler(domain domains.DomainType, node domains.YAMLDomainNode, responseHandler *handlers.ResponseHandlerStruct) *handlers.RequestHandlerStruct {
 	target := pattern.Create(domain, node.Path)
-	return handlers.RequestHandlerStruct{
+	return &handlers.RequestHandlerStruct{
 		Match: helpers.MatchRequestURL(target),
 		Fn: func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 			if !utilities.Contains(node.Methods, req.Method) {
 				return req, nil
 			}
 
-			if isRequestProfixied {
-				body := node.Request.Body
-				matches := pattern.Match(target, request.StripPort(req.URL.String()))
-				beforeHandlers := node.Request.Before
+			if responseHandler != nil {
+				hijackedResp := responseHandler.Fn(&http.Response{
+					Request: req,
+					StatusCode: http.StatusOK,
+					Status: http.StatusText(http.StatusOK),
+					Header: http.Header{},
+				}, ctx)
 
-				if len(node.Request.Headers) != 0 {
-					kv := utilities.InterfaceToMap(node.Request.Headers)
-					for key, value := range kv {
-						req.Header.Set(key, pattern.ReplaceParameters(pattern.ReplaceMatches(value, matches)))
-					}
-				}
-
-				beforeCommands := createCommands(beforeHandlers.Commands, matches)
-				runCommands(beforeCommands)
-
-				if body != "" {
-					buffer, err := readBodyFile(body, matches, req.Header)
-					if err != nil {
-						mitmErr := errors.Create(errors.ErrIOReadException, fmt.Sprintf("invalid request body for %s; %s", body, err.Error()))
-						event.MustFire(eventsService.ProxyStatusMessage, event.M{"details": mitmErr.String()})
-					} else if buffer != nil {
-						bufferLength := len(buffer)
-						req.Body = io.NopCloser(bytes.NewBuffer(buffer))
-						req.ContentLength = int64(bufferLength)
-						req.Header.Set("Content-Length", fmt.Sprintf("%d", bufferLength))
-					}
-				}
+				return req, hijackedResp
 			}
 
 			customCtx := context.ContextHandler(ctx)
 			proxified := customCtx.GetUserData("proxified")
+			if proxified == nil {
+				return req, nil
+			}
 
-			if proxified != nil {
-				pr := proxified.(map[string]bool)
-				pr["req"] = isRequestProfixied
-				pr["resp"] = isResponseProxified
-				customCtx.SetUserData("proxified", pr)
+			pr := proxified.(map[string]bool)
+			pr["req"] = true
+			customCtx.SetUserData("proxified", pr)
+
+			body := node.Request.Body
+			matches := pattern.Match(target, request.StripPort(req.URL.String()))
+			beforeHandlers := node.Request.Before
+
+			if len(node.Request.Headers) != 0 {
+				kv := utilities.InterfaceToMap(node.Request.Headers)
+				for key, value := range kv {
+					req.Header.Set(key, pattern.ReplaceParameters(pattern.ReplaceMatches(value, matches)))
+				}
+			}
+
+			beforeCommands := createCommands(beforeHandlers.Commands, matches)
+			runCommands(beforeCommands)
+
+			if body != "" {
+				buffer, err := readBodyFile(body, matches, req.Header)
+				if err != nil {
+					mitmErr := errors.Create(errors.ErrIOReadException, fmt.Sprintf("invalid request body for %s; %s", body, err.Error()))
+					event.MustFire(eventsService.ProxyStatusMessage, event.M{"details": mitmErr.String()})
+				} else if buffer != nil {
+					bufferLength := len(buffer)
+					req.Body = io.NopCloser(bytes.NewBuffer(buffer))
+					req.ContentLength = int64(bufferLength)
+					req.Header.Set("Content-Length", fmt.Sprintf("%d", bufferLength))
+				}
 			}
 
 			return req, nil
@@ -184,57 +204,55 @@ func createRequestHandler(domain domains.DomainType, node domains.YAMLDomainNode
 	}
 }
 
-func createResponseHandler(domain domains.DomainType, node domains.YAMLDomainNode, isRequestProfixied bool, isResponseProxified bool) handlers.ResponseHandlerStruct {
+func createResponseHandler(domain domains.DomainType, node domains.YAMLDomainNode) *handlers.ResponseHandlerStruct {
 	target := pattern.Create(domain, node.Path)
-	return handlers.ResponseHandlerStruct{
+	return &handlers.ResponseHandlerStruct{
 		Match: helpers.MatchResponseURL(target),
 		Fn: func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
 			if !utilities.Contains(node.Methods, resp.Request.Method) {
 				return resp
 			}
 
-			if isResponseProxified {
-				body := node.Response.Body
-				matches := pattern.Match(target, request.StripPort(resp.Request.URL.String()))
-				beforeHandlers := node.Response.Before
+			customCtx := context.ContextHandler(ctx)
+			proxified := customCtx.GetUserData("proxified")
+			if proxified == nil {
+				return resp
+			}
 
-				if len(node.Response.Headers) != 0 {
-					kv := utilities.InterfaceToMap(node.Response.Headers)
-					for key, value := range kv {
-						resp.Header.Set(key, pattern.ReplaceParameters(pattern.ReplaceMatches(value, matches)))
-					}
-				}
+			pr := proxified.(map[string]bool)
+			pr["resp"] = true
+			customCtx.SetUserData("proxified", pr)
 
-				beforeCommands := createCommands(beforeHandlers.Commands, matches)
-				runCommands(beforeCommands)
+			body := node.Response.Body
+			matches := pattern.Match(target, request.StripPort(resp.Request.URL.String()))
+			beforeHandlers := node.Response.Before
 
-				if body != "" {
-					buffer, err := readBodyFile(body, matches, resp.Request.Header)
-					if err != nil {
-						mitmErr := errors.Create(errors.ErrIOReadException, fmt.Sprintf("invalid response body for %s; %s", body, err.Error()))
-						event.MustFire(eventsService.ProxyStatusMessage, event.M{"details": mitmErr.String()})
-					} else if buffer != nil {
-						bufferLength := len(buffer)
-						resp.Body = io.NopCloser(bytes.NewBuffer(buffer))
-						resp.ContentLength = int64(bufferLength)
-						resp.Header.Set("Content-Length", fmt.Sprintf("%d", bufferLength))
-					}
-				}
-
-				if node.Response.StatusCode != 0 {
-					resp.Status = http.StatusText(node.Response.StatusCode)
-					resp.StatusCode = node.Response.StatusCode
+			if len(node.Response.Headers) != 0 {
+				kv := utilities.InterfaceToMap(node.Response.Headers)
+				for key, value := range kv {
+					resp.Header.Set(key, pattern.ReplaceParameters(pattern.ReplaceMatches(value, matches)))
 				}
 			}
 
-			customCtx := context.ContextHandler(ctx)
-			proxified := customCtx.GetUserData("proxified")
+			beforeCommands := createCommands(beforeHandlers.Commands, matches)
+			runCommands(beforeCommands)
 
-			if proxified != nil {
-				pr := proxified.(map[string]bool)
-				pr["req"] = isRequestProfixied
-				pr["resp"] = isResponseProxified
-				customCtx.SetUserData("proxified", pr)
+			if body != "" {
+				buffer, err := readBodyFile(body, matches, resp.Request.Header)
+				if err != nil {
+					mitmErr := errors.Create(errors.ErrIOReadException, fmt.Sprintf("invalid response body for %s; %s", body, err.Error()))
+					event.MustFire(eventsService.ProxyStatusMessage, event.M{"details": mitmErr.String()})
+				} else if buffer != nil {
+					bufferLength := len(buffer)
+					resp.Body = io.NopCloser(bytes.NewBuffer(buffer))
+					resp.ContentLength = int64(bufferLength)
+					resp.Header.Set("Content-Length", fmt.Sprintf("%d", bufferLength))
+				}
+			}
+
+			if node.Response.StatusCode != 0 {
+				resp.Status = http.StatusText(node.Response.StatusCode)
+				resp.StatusCode = node.Response.StatusCode
 			}
 
 			return resp

--- a/internal/application/services/mitm/handlers/main.go
+++ b/internal/application/services/mitm/handlers/main.go
@@ -34,14 +34,14 @@ type ResponseHandlerStruct struct {
 }
 
 func getUUID(customCtx *context.CustomProxyCtx) string {
-	uuid := customCtx.GetUserData("uuid").(string)
+	uuid := customCtx.GetUserData(context.IDKey).(string)
 	return uuid
 }
 
 func getSmartCache(customCtx *context.CustomProxyCtx) *smartcache.SmartCache {
 	var smartCache *smartcache.SmartCache
 
-	cacheCtx := customCtx.GetUserData("cache")
+	cacheCtx := customCtx.GetUserData(context.CacheKey)
 	if cacheCtx != nil {
 		smartCache = cacheCtx.(*smartcache.SmartCache)
 	}
@@ -50,11 +50,11 @@ func getSmartCache(customCtx *context.CustomProxyCtx) *smartcache.SmartCache {
 }
 
 func isRequestProxified(customCtx *context.CustomProxyCtx) bool {
-	proxified := customCtx.GetUserData("proxified").(map[string]bool)
+	proxified := customCtx.GetUserData(context.ProxyKey).(map[string]bool)
 	return proxified["req"]
 }
 
 func isResponseProxified(customCtx *context.CustomProxyCtx) bool {
-	proxified := customCtx.GetUserData("proxified").(map[string]bool)
+	proxified := customCtx.GetUserData(context.ProxyKey).(map[string]bool)
 	return proxified["resp"]
 }

--- a/internal/application/services/mitm/handlers/request.go
+++ b/internal/application/services/mitm/handlers/request.go
@@ -50,7 +50,7 @@ func HandleRequest(options mitm.TrafficOptions, req *http.Request, resp *http.Re
 
 	var smartCachedItem *smartcache.SmartCacheItem
 
-	if !isResponseProxified(customCtx) && smartCache != nil {
+	if !isProxified && smartCache != nil {
 		smartCachedItem = smartCache.Get(smartCache.CreateKey(
 			request.StripPort(req.URL.String()),
 			req.Header.Get("Accept"),

--- a/internal/application/services/mitm/handlers/response.go
+++ b/internal/application/services/mitm/handlers/response.go
@@ -77,7 +77,13 @@ func HandleResponse(options mitm.TrafficOptions, resp *http.Response, ctx *gopro
 		bodyBytes, _ = io.ReadAll(resp.Body)
 	}
 
-	isSmartCachable := trySmartCache && smartCachedItem == nil && resp.StatusCode >= 200 && resp.StatusCode < 300
+	isSmartCachable :=
+		!isProxified &&
+		trySmartCache &&
+		smartCachedItem == nil &&
+		resp.StatusCode == 200 &&
+		resp.StatusCode < 300
+
 	if isSmartCachable {
 		smartCache.Write(smartCacheKey, &smartcache.SmartCacheItem{
 			Body: bodyBytes,

--- a/internal/application/services/mitm/main.go
+++ b/internal/application/services/mitm/main.go
@@ -139,11 +139,11 @@ func CreateServer(f *embed.FS) (*http.Server, *errors.MITMError) {
 	proxy.OnRequest(rootCondition).DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 		var resp *http.Response
 		customCtx := context.ContextHandler(ctx)
-		customCtx.SetUserData("uuid", uuid.New().String())
-		customCtx.SetUserData("proxified", map[string]bool{"req": false, "resp": false})
+		customCtx.SetUserData(context.IDKey, uuid.New().String())
+		customCtx.SetUserData(context.ProxyKey, map[string]bool{"req": false, "resp": false})
 
 		if smartCacheEnabled && smartcache.IsRequestSmartCachable(req) {
-			customCtx.SetUserData("cache", smartCache)
+			customCtx.SetUserData(context.CacheKey, smartCache)
 		}
 
 		// :stats-svc/:title/players/:xuid/decks

--- a/internal/application/services/mitm/modules/context/main.go
+++ b/internal/application/services/mitm/modules/context/main.go
@@ -16,9 +16,17 @@ package MITMApplicationMITMServiceContextModule
 
 import "github.com/elazarl/goproxy"
 
+type dataKey string
+
+const (
+	IDKey    dataKey = "uuid"
+	ProxyKey dataKey = "proxified"
+	CacheKey dataKey = "cache"
+)
+
 type CustomProxyCtx struct {
 	*goproxy.ProxyCtx
-	UserDataMap map[string]interface{}
+	UserDataMap map[dataKey]interface{}
 }
 
 func ContextHandler(ctx *goproxy.ProxyCtx) *CustomProxyCtx {
@@ -28,18 +36,22 @@ func ContextHandler(ctx *goproxy.ProxyCtx) *CustomProxyCtx {
 
 	customCtx := &CustomProxyCtx{
 		ProxyCtx:    ctx,
-		UserDataMap: make(map[string]interface{}),
+		UserDataMap: make(map[dataKey]interface{}),
 	}
 
 	ctx.UserData = customCtx
 	return customCtx
 }
 
-func (c *CustomProxyCtx) SetUserData(key string, value interface{}) {
+func (c *CustomProxyCtx) SetUserData(key dataKey, value interface{}) {
 	c.UserDataMap[key] = value
 }
 
-func (c *CustomProxyCtx) GetUserData(key string) interface{} {
+func (c *CustomProxyCtx) UnsetUserData(key dataKey) {
+	delete(c.UserDataMap, key)
+}
+
+func (c *CustomProxyCtx) GetUserData(key dataKey) interface{} {
 	return c.UserDataMap[key]
 }
 

--- a/internal/application/tools/select-servers/main.go
+++ b/internal/application/tools/select-servers/main.go
@@ -86,7 +86,7 @@ func GetPingTime(serverURL string) (*probing.Statistics, *errors.MITMError) {
 		return nil, errors.Create(errors.ErrPingFailedException, err.Error())
 	}
 
-	pinger.Count = 1
+	pinger.Count = 3
 	pinger.Timeout = time.Second * 5
 
 	err = pinger.Run()

--- a/pkg/utilities/main.go
+++ b/pkg/utilities/main.go
@@ -85,8 +85,6 @@ func WrapText(text string, width int) string {
 	return sb.String()
 }
 
-
-
 func FormatHexView(data []byte, width int) string {
 	bytesPerLine := (width - 10)
 	if bytesPerLine <= 10 {


### PR DESCRIPTION
- [fix] Ensure hijacking of request's response on custom `response.body`
- [fix] Use library for ping requests instead of ping command
- [fix] Run all request overrides even when the response is hijacked
- [fix] Assign external `response.body` (URL) response headers
- [fix] Fallback to default servers on ping error
- [fix] Omit SmartCache on "proxified" requests/responses
- [fix] Use average ping response time