### PR TITLE
fix(select-servers): properly deprioritize unselected servers by using highest ping

### DIFF
--- a/configs/application.yaml
+++ b/configs/application.yaml
@@ -1,6 +1,6 @@
 name: InfiniteMITM
 description: A MITM (man-in-the-middle) CLI for Halo Infinite
-version: 0.5.6
+version: 0.5.7
 author: Alexis Bize
 repository: https://github.com/Alexis-Bize/InfiniteMITM
 proxy:

--- a/internal/application/ui/tools/select-servers/main.go
+++ b/internal/application/ui/tools/select-servers/main.go
@@ -190,15 +190,14 @@ func (m *model) saveServers() {
     var updatedServers = selectServersTool.QOSServers{}
     
     if len(m.selectedRegions) != 0 {
-        var bestSelectedServerURL string
-        lowestPing := int(^uint(0) >> 1)
+        var worstServerURL string
+        highestPing := -1
 
         for _, result := range m.pingResults {
-            if utilities.Contains(m.selectedRegions, result.Region) && 
-               result.Ping != selectServersTool.PingErrorValue && 
-               result.Ping < lowestPing {
-                lowestPing = result.Ping
-                bestSelectedServerURL = result.ServerURL
+            if result.Ping != selectServersTool.PingErrorValue && 
+               result.Ping > highestPing {
+                highestPing = result.Ping
+                worstServerURL = result.ServerURL
             }
         }
 
@@ -209,8 +208,8 @@ func (m *model) saveServers() {
             
             if utilities.Contains(m.selectedRegions, server.Region) {
                 newServer.ServerURL = server.ServerURL
-            } else if bestSelectedServerURL != "" {
-                newServer.ServerURL = bestSelectedServerURL
+            } else if worstServerURL != "" {
+                newServer.ServerURL = worstServerURL
             } else {
                 newServer.ServerURL = server.ServerURL
             }


### PR DESCRIPTION
Version 0.5.6 introduced a minor issue where unselected servers were replaced by the selected ones.