### PR TITLE
refacto: 0.7.0

### DIFF
--- a/configs/application.yaml
+++ b/configs/application.yaml
@@ -1,6 +1,6 @@
 name: InfiniteMITM
 description: A MITM (man-in-the-middle) CLI for Halo Infinite
-version: 0.6.0
+version: 0.7.0
 author: Alexis Bize
 repository: https://github.com/Alexis-Bize/InfiniteMITM
 proxy:

--- a/internal/application/services/events/main.go
+++ b/internal/application/services/events/main.go
@@ -14,8 +14,6 @@
 
 package MITMApplicationEventsService
 
-import "encoding/json"
-
 const (
 	RestartServer = "server.restart"
 	ProxyRequestSent = "request.sent"
@@ -23,45 +21,25 @@ const (
 	ProxyStatusMessage = "proxy.status_message"
 )
 
+const PayloadKey = "data"
+
 type ProxyRequestEventData struct {
-	ID          string `json:"id"`
-	URL         string `json:"url"`
-	Method      string `json:"method"`
-	Headers     map[string]string `json:"headers"`
-	Body        []byte `json:"body"`
-	Proxified   bool `json:"proxified"`
-	SmartCached bool `json:"smart_cached"`
+	ID          string
+	URL         string
+	Method      string
+	Headers     map[string]string
+	Body        []byte
+	Proxified   bool
+	SmartCached bool
 }
 
 type ProxyResponseEventData struct {
-	ID          string `json:"id"`
-	URL         string `json:"url"`
-	Method      string `json:"method"`
-	Status      int `json:"status"`
-	Headers     map[string]string `json:"headers"`
-	Body        []byte `json:"body"`
-	Proxified   bool `json:"proxified"`
-	SmartCached bool `json:"smart_cached"`
-}
-
-func StringifyRequestEventData(data ProxyRequestEventData) string {
-	marshal, _ := json.Marshal(data)
-	return string(marshal)
-}
-
-func StringifyResponseEventData(data ProxyResponseEventData) string {
-	marshal, _ := json.Marshal(data)
-	return string(marshal)
-}
-
-func ParseRequestEventData(data string) ProxyRequestEventData {
-	var unmarshal ProxyRequestEventData
-	json.Unmarshal([]byte(data), &unmarshal)
-	return unmarshal
-}
-
-func ParseResponseEventData(data string) ProxyResponseEventData {
-	var unmarshal ProxyResponseEventData
-	json.Unmarshal([]byte(data), &unmarshal)
-	return unmarshal
+	ID          string
+	URL         string
+	Method      string
+	Status      int
+	Headers     map[string]string
+	Body        []byte
+	Proxified   bool
+	SmartCached bool
 }

--- a/internal/application/services/mitm/client.go
+++ b/internal/application/services/mitm/client.go
@@ -157,11 +157,8 @@ func createRequestHandler(domain domains.DomainType, node domains.YAMLDomainNode
 			matches := pattern.Match(target, request.StripPort(req.URL.String()))
 			beforeHandlers := node.Request.Before
 
-			if len(node.Request.Headers) != 0 {
-				kv := utilities.InterfaceToMap(node.Request.Headers)
-				for key, value := range kv {
-					req.Header.Set(key, pattern.ReplaceParameters(pattern.ReplaceMatches(value, matches)))
-				}
+			for key, value := range node.Request.Headers {
+				req.Header.Set(key, pattern.ReplaceParameters(pattern.ReplaceMatches(value, matches)))
 			}
 
 			beforeCommands := createCommands(beforeHandlers.Commands, matches)
@@ -173,6 +170,11 @@ func createRequestHandler(domain domains.DomainType, node domains.YAMLDomainNode
 					mitmErr := errors.Create(errors.ErrIOReadException, fmt.Sprintf("invalid request body for %s; %s", body, err.Error()))
 					event.MustFire(eventsService.ProxyStatusMessage, event.M{"details": mitmErr.String()})
 				} else if buffer != nil {
+					if req.Body != nil {
+						io.Copy(io.Discard, req.Body)
+						req.Body.Close()
+					}
+
 					bufferLength := len(buffer)
 					req.Body = io.NopCloser(bytes.NewBuffer(buffer))
 					req.ContentLength = int64(bufferLength)
@@ -220,11 +222,8 @@ func createResponseHandler(domain domains.DomainType, node domains.YAMLDomainNod
 			matches := pattern.Match(target, request.StripPort(resp.Request.URL.String()))
 			beforeHandlers := node.Response.Before
 
-			if len(node.Response.Headers) != 0 {
-				kv := utilities.InterfaceToMap(node.Response.Headers)
-				for key, value := range kv {
-					resp.Header.Set(key, pattern.ReplaceParameters(pattern.ReplaceMatches(value, matches)))
-				}
+			for key, value := range node.Response.Headers {
+				resp.Header.Set(key, pattern.ReplaceParameters(pattern.ReplaceMatches(value, matches)))
 			}
 
 			beforeCommands := createCommands(beforeHandlers.Commands, matches)
@@ -236,6 +235,11 @@ func createResponseHandler(domain domains.DomainType, node domains.YAMLDomainNod
 					mitmErr := errors.Create(errors.ErrIOReadException, fmt.Sprintf("invalid response body for %s; %s", body, err.Error()))
 					event.MustFire(eventsService.ProxyStatusMessage, event.M{"details": mitmErr.String()})
 				} else if buffer != nil {
+					if resp.Body != nil {
+						io.Copy(io.Discard, resp.Body)
+						resp.Body.Close()
+					}
+
 					for k, v := range httpHeader {
 						resp.Header.Set(k, strings.Join(v, ", "))
 					}
@@ -269,29 +273,31 @@ func isURL(str string) bool {
 	return err == nil && u.Scheme != "" && u.Host != ""
 }
 
-func createCommands(commands []domains.YAMLDomainTrafficRunCommand, matches []string) []string {
-	var commandsList []string
+func createCommands(commands []domains.YAMLDomainTrafficRunCommand, matches []string) [][]string {
+	var commandsList [][]string
 
-	if len(commands) != 0 {
-		for _, commands := range commands {
-			var runList []string
-			for _, run := range commands.Run {
-				replace := pattern.ReplaceParameters(pattern.ReplaceMatches(run, matches))
-				if !isURL(replace) {
-					replace = filepath.Clean(replace)
-				}
+	for _, command := range commands {
+		if len(command.Run) == 0 {
+			continue
+		}
 
-				runList = append(runList, replace)
+		runList := make([]string, 0, len(command.Run))
+		for _, run := range command.Run {
+			replace := pattern.ReplaceParameters(pattern.ReplaceMatches(run, matches))
+			if !isURL(replace) {
+				replace = filepath.Clean(replace)
 			}
 
-			commandsList = append(commandsList, strings.Join(runList, " "))
+			runList = append(runList, replace)
 		}
+
+		commandsList = append(commandsList, runList)
 	}
 
 	return commandsList
 }
 
-func runCommands(commands []string) {
+func runCommands(commands [][]string) {
 	if len(commands) == 0 {
 		return
 	}
@@ -299,27 +305,19 @@ func runCommands(commands []string) {
 	var wg sync.WaitGroup
 	wg.Add(len(commands))
 
-	for i, cmd := range commands {
-		go func(i int, cmd string) {
+	for i, args := range commands {
+		go func(i int, args []string) {
 			defer wg.Done()
 
-			args := strings.Split(cmd, " ")
-			length := len(args)
-			if length == 0 {
+			if len(args) == 0 {
 				return
 			}
 
-			var c *exec.Cmd
-			if length == 1 {
-				c = exec.Command(args[0])
-			} else if length >= 2 {
-				c = exec.Command(args[0], args[1:]...)
-			}
-
+			c := exec.Command(args[0], args[1:]...)
 			if err := c.Run(); err != nil {
 				event.MustFire(eventsService.ProxyStatusMessage, event.M{"details": fmt.Sprintf("command #%d encountered an error: %s", i + 1, err.Error())})
 			}
-		}(i, cmd)
+		}(i, args)
 	}
 
 	wg.Wait()

--- a/internal/application/services/mitm/handlers/request.go
+++ b/internal/application/services/mitm/handlers/request.go
@@ -81,20 +81,22 @@ func HandleRequest(options mitm.TrafficOptions, req *http.Request, resp *http.Re
 		var bodyBytes []byte
 		if req.Body != nil {
 			bodyBytes, _ = io.ReadAll(req.Body)
+			req.Body.Close()
 		}
 
 		headersMap := request.HeadersToMap(req.Header)
-		details := eventsService.StringifyRequestEventData(eventsService.ProxyRequestEventData{
-			ID: uuid,
-			URL: req.URL.String(),
-			Method: req.Method,
-			Headers: headersMap,
-			Body: bodyBytes,
-			Proxified: isProxified,
-			SmartCached: !isProxified && smartCache != nil,
+		event.MustFire(eventsService.ProxyRequestSent, event.M{
+			eventsService.PayloadKey: eventsService.ProxyRequestEventData{
+				ID: uuid,
+				URL: req.URL.String(),
+				Method: req.Method,
+				Headers: headersMap,
+				Body: bodyBytes,
+				Proxified: isProxified,
+				SmartCached: !isProxified && smartCache != nil,
+			},
 		})
 
-		event.MustFire(eventsService.ProxyRequestSent, event.M{"details": details})
 		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	}
 

--- a/internal/application/services/mitm/handlers/response.go
+++ b/internal/application/services/mitm/handlers/response.go
@@ -56,11 +56,9 @@ func HandleResponse(options mitm.TrafficOptions, resp *http.Response, ctx *gopro
 		resp.Header.Set(request.ExpiresHeaderKey, "0")
 	}
 
-	var bodyBytes []byte
+	trySmartCache := !isSmartCached && smartCache != nil
 	var smartCacheKey string
 	var smartCachedItem *smartcache.SmartCacheItem
-
-	trySmartCache := !isSmartCached && smartCache != nil
 	if trySmartCache {
 		smartCacheKey = smartCache.CreateKey(
 			request.StripPort(resp.Request.URL.String()),
@@ -71,18 +69,30 @@ func HandleResponse(options mitm.TrafficOptions, resp *http.Response, ctx *gopro
 		smartCachedItem = smartCache.Get(smartCacheKey)
 	}
 
-	if smartCachedItem != nil {
-		bodyBytes = smartCachedItem.Body
-	} else {
-		bodyBytes, _ = io.ReadAll(resp.Body)
-	}
-
 	isSmartCachable :=
 		!isProxified &&
 		trySmartCache &&
 		smartCachedItem == nil &&
 		resp.StatusCode == 200 &&
 		resp.StatusCode < 300
+
+	shouldDispatch := options.TrafficDisplay == mitm.TrafficAll || (
+		options.TrafficDisplay == mitm.TrafficOverrides && isProxified ||
+		options.TrafficDisplay == mitm.TrafficSmartCache && !isProxified && smartCache != nil)
+
+	needBody := smartCachedItem != nil || isSmartCachable || shouldDispatch
+
+	var bodyBytes []byte
+	if smartCachedItem != nil {
+		bodyBytes = smartCachedItem.Body
+		if resp.Body != nil {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
+	} else if needBody && resp.Body != nil {
+		bodyBytes, _ = io.ReadAll(resp.Body)
+		resp.Body.Close()
+	}
 
 	if isSmartCachable {
 		smartCache.Write(smartCacheKey, &smartcache.SmartCacheItem{
@@ -93,26 +103,25 @@ func HandleResponse(options mitm.TrafficOptions, resp *http.Response, ctx *gopro
 		resp.Header.Set(request.MITMCacheHeaderKey, request.MITMCacheHeaderMissValue)
 	}
 
-	shouldDispatch := options.TrafficDisplay == mitm.TrafficAll || (
-		options.TrafficDisplay == mitm.TrafficOverrides && isProxified ||
-		options.TrafficDisplay == mitm.TrafficSmartCache && !isProxified && smartCache != nil)
-
 	if shouldDispatch {
 		headersMap := request.HeadersToMap(resp.Header)
-		details := eventsService.StringifyResponseEventData(eventsService.ProxyResponseEventData{
-			ID: uuid,
-			URL: resp.Request.URL.String(),
-			Method: resp.Request.Method,
-			Status: resp.StatusCode,
-			Headers: headersMap,
-			Body: bodyBytes,
-			Proxified: isProxified,
-			SmartCached: !isProxified && (isSmartCached || smartCache != nil),
+		event.MustFire(eventsService.ProxyResponseReceived, event.M{
+			eventsService.PayloadKey: eventsService.ProxyResponseEventData{
+				ID: uuid,
+				URL: resp.Request.URL.String(),
+				Method: resp.Request.Method,
+				Status: resp.StatusCode,
+				Headers: headersMap,
+				Body: bodyBytes,
+				Proxified: isProxified,
+				SmartCached: !isProxified && (isSmartCached || smartCache != nil),
+			},
 		})
-
-		event.MustFire(eventsService.ProxyResponseReceived, event.M{"details": details})
 	}
 
-	resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	if needBody {
+		resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	}
+
 	return resp
 }

--- a/internal/application/services/mitm/main.go
+++ b/internal/application/services/mitm/main.go
@@ -16,7 +16,6 @@ package MITMApplicationMITMService
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"embed"
 	"fmt"
 	"infinite-mitm/configs"
@@ -30,6 +29,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/elazarl/goproxy"
 	"github.com/google/uuid"
@@ -54,15 +54,19 @@ func CreateServer(f *embed.FS) (*http.Server, *errors.MITMError) {
 		return nil, errors.Create(errors.ErrProxyCertificateException, err.Error())
 	}
 
-	CACertPool := x509.NewCertPool(); if !CACertPool.AppendCertsFromPEM(CACert) {
-		return nil, errors.Create(errors.ErrProxyCertificateException, "failed to add root CA certificate to pool")
-	}
-
 	goproxy.GoproxyCa = cert
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.Verbose = false
 	proxy.KeepHeader = false
 	proxy.Logger = emptyLogger{}
+
+	if proxy.Tr != nil {
+		proxy.Tr.MaxIdleConns = 100
+		proxy.Tr.MaxIdleConnsPerHost = 32
+		proxy.Tr.IdleConnTimeout = 90 * time.Second
+		proxy.Tr.ResponseHeaderTimeout = 30 * time.Second
+		proxy.Tr.ExpectContinueTimeout = 1 * time.Second
+	}
 
 	content, mitmErr := mitm.ReadClientMITMConfig(); if mitmErr != nil {
 		event.MustFire(eventsService.ProxyStatusMessage, event.M{"details": mitmErr.String()})
@@ -177,11 +181,6 @@ func CreateServer(f *embed.FS) (*http.Server, *errors.MITMError) {
 	server := &http.Server{
 		Addr: fmt.Sprintf(":%d", configs.GetConfig().Proxy.Port),
 		Handler: proxy,
-		TLSConfig: &tls.Config{
-			RootCAs: CACertPool,
-			Certificates: []tls.Certificate{cert},
-			InsecureSkipVerify: true,
-		},
 	}
 
 	return server, nil

--- a/internal/application/tools/select-servers/main.go
+++ b/internal/application/tools/select-servers/main.go
@@ -106,8 +106,14 @@ func ReadLocalQOSServers() QOSServers {
 
 func WriteLocalQOSServers(servers QOSServers) {
 	serverFilepath := filepath.Join(resources.GetDirPaths()[resources.JsonDirKey], integrity.QOSServersFilename)
-	buffer, err := json.Marshal(servers); if err == nil {
-		os.WriteFile(serverFilepath, buffer, 0644)
+	buffer, err := json.Marshal(servers)
+	if err != nil {
+		errors.Create(errors.ErrIOWriteException, err.Error()).Log()
+		return
+	}
+
+	if err := os.WriteFile(serverFilepath, buffer, 0644); err != nil {
+		errors.Create(errors.ErrIOWriteException, err.Error()).Log()
 	}
 }
 

--- a/internal/application/ui/network/main.go
+++ b/internal/application/ui/network/main.go
@@ -28,7 +28,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -63,10 +62,23 @@ const (
 	EnterCommand     = "enter"
 	PruneRowsCommand = "ctrl+r"
 )
+
+const (
+	maxStoredEntries  = 2000
+	evictionChunkSize = 500
+	uiBufferSize      = 4096
+)
+
 var (
 	once    sync.Once
 	program *tea.Program
+
+	uiMsgChan = make(chan tea.Msg, uiBufferSize)
 )
+
+func sendUI(msg tea.Msg) {
+	uiMsgChan <- msg
+}
 
 var (
 	networkDataMutex = &sync.Mutex{}
@@ -74,6 +86,7 @@ var (
 		Requests:  make(map[string]eventsService.ProxyRequestEventData),
 		Responses: make(map[string]eventsService.ProxyResponseEventData),
 	}
+	networkDataOrder = make([]string, 0, maxStoredEntries+evictionChunkSize)
 )
 
 func Create() {
@@ -92,40 +105,53 @@ func Create() {
 
 	m.networkTableModel.Focus()
 
+	program = tea.NewProgram(m)
+
 	once.Do(func() {
+		go func() {
+			for msg := range uiMsgChan {
+				if program != nil {
+					program.Send(msg)
+				}
+			}
+		}()
+
 		event.On(eventsService.ProxyRequestSent, event.ListenerFunc(func(e event.Event) error {
-			details := e.Data()["details"].(string)
-			data := eventsService.ParseRequestEventData(details)
-			go pushNetworkData(data)
+			if data, ok := e.Data()[eventsService.PayloadKey].(eventsService.ProxyRequestEventData); ok {
+				pushNetworkData(data)
+			}
 
 			return nil
 		}), event.Normal)
 
 		event.On(eventsService.ProxyResponseReceived, event.ListenerFunc(func(e event.Event) error {
-			details := e.Data()["details"].(string)
-			data := eventsService.ParseResponseEventData(details)
-			go updateNetworkData(data)
+			if data, ok := e.Data()[eventsService.PayloadKey].(eventsService.ProxyResponseEventData); ok {
+				updateNetworkData(data)
+			}
 
 			return nil
 		}), event.Normal)
 
 		event.On(eventsService.ProxyStatusMessage, event.ListenerFunc(func(e event.Event) error {
 			details := e.Data()["details"].(string)
-			go updateStatusBar(details)
+			updateStatusBar(details)
 
 			return nil
 		}), event.Normal)
 	})
 
-	program = tea.NewProgram(m)
 	if _, err := program.Run(); err != nil {
 		log.Fatalln(errors.Create(errors.ErrFatalException, err.Error()))
 	}
 }
 
 func pruneNetworkData() {
+	networkDataMutex.Lock()
+	defer networkDataMutex.Unlock()
+
 	networkData.Requests = make(map[string]eventsService.ProxyRequestEventData)
 	networkData.Responses = make(map[string]eventsService.ProxyResponseEventData)
+	networkDataOrder = networkDataOrder[:0]
 }
 
 func (m *model) setActiveElement(key activeKeyType) {
@@ -279,15 +305,27 @@ func pushNetworkData(data eventsService.ProxyRequestEventData) {
 
 	networkDataMutex.Lock()
 	networkData.Requests[data.ID] = data
+	networkDataOrder = append(networkDataOrder, data.ID)
+	if len(networkDataOrder) > maxStoredEntries {
+		for i := 0; i < evictionChunkSize; i++ {
+			evictID := networkDataOrder[i]
+			delete(networkData.Requests, evictID)
+			delete(networkData.Responses, evictID)
+		}
+
+		remaining := len(networkDataOrder) - evictionChunkSize
+		copy(networkDataOrder, networkDataOrder[evictionChunkSize:])
+		networkDataOrder = networkDataOrder[:remaining]
+	}
 	networkDataMutex.Unlock()
 
-	program.Send(details.RequestTraffic(details.RequestTraffic{
+	sendUI(details.RequestTraffic(details.RequestTraffic{
 		ID: data.ID,
 		Headers: data.Headers,
 		Body: data.Body,
 	}))
 
-	program.Send(table.TableRowMsg(table.TableRowMsg{
+	sendUI(table.TableRowMsg(table.TableRowMsg{
 		ID: data.ID,
 		Prefix: prefix,
 		Method: data.Method,
@@ -329,19 +367,18 @@ func updateNetworkData(data eventsService.ProxyResponseEventData) {
 	networkData.Responses[data.ID] = data
 	networkDataMutex.Unlock()
 
-	program.Send(details.ResponseStatus(details.ResponseStatus{
+	sendUI(details.ResponseStatus(details.ResponseStatus{
 		ID: data.ID,
 		Status: data.Status,
 	}))
 
-	program.Send(details.ResponseTraffic(details.ResponseTraffic{
+	sendUI(details.ResponseTraffic(details.ResponseTraffic{
 		ID: data.ID,
 		Headers: data.Headers,
 		Body: data.Body,
 	}))
 
-	time.Sleep(100 * time.Millisecond)
-	program.Send(table.TableRowMsg(table.TableRowMsg{
+	sendUI(table.TableRowMsg(table.TableRowMsg{
 		ID: data.ID,
 		Prefix: prefix,
 		Method: data.Method,
@@ -353,7 +390,7 @@ func updateNetworkData(data eventsService.ProxyResponseEventData) {
 }
 
 func updateStatusBar(message string) {
-	program.Send(status.StatusBarInfoUpdate(status.StatusBarInfoUpdate{
+	sendUI(status.StatusBarInfoUpdate(status.StatusBarInfoUpdate{
 		Message: message,
 	}))
 }

--- a/internal/application/ui/tools/select-servers/main.go
+++ b/internal/application/ui/tools/select-servers/main.go
@@ -157,7 +157,7 @@ func (m *model) setPingForRegion(result selectServersTool.PingResult) tea.Cmd {
 		m.pingFinished = true
 	}
 
-	return tea.Batch()
+	return nil
 }
 
 func (m *model) toggleRegion() {

--- a/internal/main.go
+++ b/internal/main.go
@@ -155,6 +155,10 @@ func restartServer(f *embed.FS, wg *sync.WaitGroup) {
 func stopServer() {
 	disableProxy()
 
+	if server == nil {
+		return
+	}
+
 	if err := server.Close(); err != nil {
 		errors.Create(errors.ErrProxyServerException, err.Error()).Log()
 	}

--- a/pkg/errors/main.go
+++ b/pkg/errors/main.go
@@ -44,6 +44,7 @@ var (
 	ErrPromptException = errors.New("prompt exception")
 	ErrWatcherException = errors.New("watcher exception")
 	ErrIOReadException = errors.New("io read exception")
+	ErrIOWriteException = errors.New("io write exception")
 	ErrMITMYamlSchemaOutdatedException = errors.New("mitm yaml schema outdated exception")
 	ErrIntegrityYamlSchemaOutdatedException = errors.New("integrity yaml schema outdated exception")
 	ErrPingFailedException = errors.New("ping failed exception")

--- a/pkg/integrity/main.go
+++ b/pkg/integrity/main.go
@@ -60,7 +60,13 @@ func ReadIntegrityConfig() (YAML, *errors.MITMError) {
 }
 
 func WriteIntegrityFile(content YAML) {
-	buffer, err := yaml.Marshal(content); if err == nil {
-		os.WriteFile(IntegrityFilepath, buffer, 0644)
+	buffer, err := yaml.Marshal(content)
+	if err != nil {
+		errors.Create(errors.ErrIOWriteException, err.Error()).Log()
+		return
+	}
+
+	if err := os.WriteFile(IntegrityFilepath, buffer, 0644); err != nil {
+		errors.Create(errors.ErrIOWriteException, err.Error()).Log()
 	}
 }

--- a/pkg/mitm/main.go
+++ b/pkg/mitm/main.go
@@ -74,7 +74,13 @@ func ReadClientMITMConfig() (YAML, *errors.MITMError) {
 }
 
 func WriteMITMFile(content YAML) {
-	buffer, err := yaml.Marshal(content); if err == nil {
-		os.WriteFile(MITMFilepath, buffer, 0644)
+	buffer, err := yaml.Marshal(content)
+	if err != nil {
+		errors.Create(errors.ErrIOWriteException, err.Error()).Log()
+		return
+	}
+
+	if err := os.WriteFile(MITMFilepath, buffer, 0644); err != nil {
+		errors.Create(errors.ErrIOWriteException, err.Error()).Log()
 	}
 }

--- a/pkg/pattern/main.go
+++ b/pkg/pattern/main.go
@@ -34,9 +34,10 @@ type Patterns struct {
 const MITMDirPrefix = ":mitm-dir"
 
 var (
-	mitmDirs     map[string]string
-	mitmDirsKeys []string
-	replacer     *strings.Replacer
+	mitmDirs       map[string]string
+	mitmDirsKeys   []string
+	replacer       *strings.Replacer
+	matchRefRegexp = regexp.MustCompile(`\$\d+`)
 )
 
 var MatchParameters = Patterns{
@@ -159,8 +160,8 @@ func Create(domain domains.DomainType, path string) *regexp.Regexp {
 		path = "/" + path
 	}
 
-	path = strings.Replace(path, "*", ":all", -1)
-	path = strings.Replace(path, "$", ":end", -1)
+	path = strings.ReplaceAll(path, "*", ":all")
+	path = strings.ReplaceAll(path, "$", ":end")
 	path = ReplaceParameters(escapeExceptParentheses(path))
 
 	re := regexp.MustCompile(`(?i)` + regexp.QuoteMeta(domain) + path)
@@ -176,8 +177,7 @@ func ReplaceParameters(value string) string {
 }
 
 func ReplaceMatches(target string, matches []string) string {
-	re := regexp.MustCompile(`\$\d+`)
-	return re.ReplaceAllStringFunc(target, func(m string) string {
+	return matchRefRegexp.ReplaceAllStringFunc(target, func(m string) string {
 		index, err := strconv.Atoi(m[1:])
 		if err != nil || index < 1 || index > len(matches) {
 			return ""

--- a/pkg/proxy/main.go
+++ b/pkg/proxy/main.go
@@ -27,6 +27,10 @@ import (
 var proxyHost = configs.GetConfig().Proxy.Host
 var proxyPort = strconv.Itoa(configs.GetConfig().Proxy.Port)
 
+const darwinFallbackService = "Wi-Fi"
+
+var darwinActiveService = darwinFallbackService
+
 func ToggleProxy(command string) *errors.MITMError {
 	if command != "on" && command != "off" {
 		return errors.Create(errors.ErrProxyToggleInvalidCommand, "invalid command")
@@ -73,16 +77,18 @@ func enableProxyWindows() error {
 }
 
 func enableProxyDarwin() error {
-	commands := []string{
-		fmt.Sprintf("networksetup -setwebproxy Wi-Fi %s %s", proxyHost, proxyPort),
-		fmt.Sprintf("networksetup -setsecurewebproxy Wi-Fi %s %s", proxyHost, proxyPort),
-		"networksetup -setwebproxystate Wi-Fi on",
-		"networksetup -setsecurewebproxystate Wi-Fi on",
+	darwinActiveService = detectDarwinActiveService()
+	service := darwinActiveService
+
+	commands := [][]string{
+		{"networksetup", "-setwebproxy", service, proxyHost, proxyPort},
+		{"networksetup", "-setsecurewebproxy", service, proxyHost, proxyPort},
+		{"networksetup", "-setwebproxystate", service, "on"},
+		{"networksetup", "-setsecurewebproxystate", service, "on"},
 	}
 
-	for _, cmd := range commands {
-		parts := strings.Fields(cmd)
-		if err := exec.Command(parts[0], parts[1:]...).Run(); err != nil {
+	for _, args := range commands {
+		if err := exec.Command(args[0], args[1:]...).Run(); err != nil {
 			return err
 		}
 	}
@@ -95,17 +101,69 @@ func disableProxyWindows() error {
 }
 
 func disableProxyDarwin() error {
-	commands := []string{
-		"networksetup -setwebproxystate Wi-Fi off",
-		"networksetup -setsecurewebproxystate Wi-Fi off",
+	service := darwinActiveService
+
+	commands := [][]string{
+		{"networksetup", "-setwebproxystate", service, "off"},
+		{"networksetup", "-setsecurewebproxystate", service, "off"},
 	}
 
-	for _, cmd := range commands {
-		parts := strings.Fields(cmd)
-		if err := exec.Command(parts[0], parts[1:]...).Run(); err != nil {
+	for _, args := range commands {
+		if err := exec.Command(args[0], args[1:]...).Run(); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func detectDarwinActiveService() string {
+	iface := defaultDarwinInterface()
+	if iface == "" {
+		return darwinFallbackService
+	}
+
+	out, err := exec.Command("networksetup", "-listnetworkserviceorder").Output()
+	if err != nil {
+		return darwinFallbackService
+	}
+
+	devSuffix := "Device: " + iface + ")"
+	lines := strings.Split(string(out), "\n")
+
+	for i := 1; i < len(lines); i++ {
+		portLine := strings.TrimSpace(lines[i])
+		if !strings.HasPrefix(portLine, "(Hardware Port:") || !strings.HasSuffix(portLine, devSuffix) {
+			continue
+		}
+
+		serviceLine := strings.TrimSpace(lines[i-1])
+		if idx := strings.Index(serviceLine, ") "); idx > 0 {
+			name := strings.TrimSpace(serviceLine[idx+2:])
+			if name != "" {
+				return name
+			}
+		}
+	}
+
+	return darwinFallbackService
+}
+
+func defaultDarwinInterface() string {
+	out, err := exec.Command("route", "-n", "get", "default").Output()
+	if err != nil {
+		return ""
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "interface:") {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				return parts[len(parts)-1]
+			}
+		}
+	}
+
+	return ""
 }

--- a/pkg/request/main.go
+++ b/pkg/request/main.go
@@ -83,7 +83,8 @@ func StripPort(u string) string {
 		return u
 	}
 
-	return strings.Replace(parse.String(), fmt.Sprintf(":%s", parse.Port()), "", -1)
+	parse.Host = parse.Hostname()
+	return parse.String()
 }
 
 func HeadersToMap(header http.Header) map[string]string {

--- a/pkg/smartcache/main.go
+++ b/pkg/smartcache/main.go
@@ -20,6 +20,7 @@ import (
 	"encoding/gob"
 	"encoding/hex"
 	"fmt"
+	"hash/fnv"
 	"infinite-mitm/pkg/domains"
 	"infinite-mitm/pkg/request"
 	"infinite-mitm/pkg/resources"
@@ -62,12 +63,19 @@ const (
 const (
 	version = 2
 	defaultDuration = 7 * 24 * time.Hour
+	lockStripeCount = 64
 )
 
 var (
-	mutexes = &sync.Map{}
+	lockStripes          [lockStripeCount]sync.Mutex
 	flushSmartCacheMutex = &sync.Mutex{}
 )
+
+func keyStripe(key string) *sync.Mutex {
+	h := fnv.New32a()
+	h.Write([]byte(key))
+	return &lockStripes[h.Sum32()%lockStripeCount]
+}
 
 func init() {
 	gob.Register(http.Header{})
@@ -99,11 +107,9 @@ func Flush() {
 }
 
 func (s *SmartCache) Get(key string) *SmartCacheItem {
-	mutex, _ := mutexes.LoadOrStore(key, &sync.Mutex{})
-	currentMutex := mutex.(*sync.Mutex)
-
-	currentMutex.Lock()
-	defer currentMutex.Unlock()
+	mutex := keyStripe(key)
+	mutex.Lock()
+	defer mutex.Unlock()
 
 	if s.strategy == Persistent {
 		target := filepath.Join(resources.GetSmartCacheDirPath(), key)
@@ -149,11 +155,9 @@ func (s *SmartCache) Get(key string) *SmartCacheItem {
 }
 
 func (s *SmartCache) Write(key string, item *SmartCacheItem) {
-	mutex, _ := mutexes.LoadOrStore(key, &sync.Mutex{})
-	currentMutex := mutex.(*sync.Mutex)
-
-	currentMutex.Lock()
-	defer currentMutex.Unlock()
+	mutex := keyStripe(key)
+	mutex.Lock()
+	defer mutex.Unlock()
 
 	item.Created = time.Now()
 	item.Expires = time.Now().Add(s.duration)
@@ -172,7 +176,7 @@ func (s *SmartCache) Write(key string, item *SmartCacheItem) {
 	var buf bytes.Buffer
 	encoder := gob.NewEncoder(&buf)
 	if err := encoder.Encode(item); err == nil {
-		os.WriteFile(target, buf.Bytes(), 0666)
+		os.WriteFile(target, buf.Bytes(), 0644)
 	}
 }
 

--- a/pkg/sysutilities/main.go
+++ b/pkg/sysutilities/main.go
@@ -28,11 +28,14 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/atotto/clipboard"
 	"github.com/ncruces/zenity"
 	"golang.org/x/term"
 )
+
+var downloadClient = &http.Client{Timeout: 60 * time.Second}
 
 func GetHomeDirectory() (string, *errors.MITMError) {
 	home, err := os.UserHomeDir(); if err != nil {
@@ -67,11 +70,15 @@ func OpenBrowser(url string) {
 }
 
 func DownloadFile(url string) ([]byte, *errors.MITMError) {
-	response, err := http.Get(url)
+	response, err := downloadClient.Get(url)
 	if err != nil {
 		return nil, errors.Create(errors.ErrFatalException, err.Error())
 	}
 	defer response.Body.Close()
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, errors.Create(errors.ErrHTTPCodeError, fmt.Sprintf("status code: %d", response.StatusCode))
+	}
 
 	data, err := io.ReadAll(response.Body)
 	if err != nil {
@@ -86,10 +93,6 @@ func CopyToClipboard(data string) {
 }
 
 func SaveToDisk(data []byte, outputDir string, filename string, contentType string) {
-	defer func() {
-		_ = recover();
-	}()
-
 	contentType = strings.Split(contentType, ";")[0]
 	var mimeExtensions = map[string]string{
 		"application/json":         "json",

--- a/pkg/updater/main.go
+++ b/pkg/updater/main.go
@@ -36,6 +36,10 @@ func CheckForApplicationUpdate() (bool, string, *errors.MITMError) {
 		return false, "", err
 	}
 
+	if releases == nil || len(*releases) == 0 {
+		return false, "", nil
+	}
+
 	latestRelease := (*releases)[0]
 	newVersionAvailable, versionErr := isNewVersionAvailable(configs.GetConfig().Version, latestRelease.TagName)
 	if versionErr != nil {

--- a/pkg/utilities/main.go
+++ b/pkg/utilities/main.go
@@ -17,17 +17,12 @@ package utilities
 import (
 	"encoding/hex"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 )
 
 func Contains(slice []string, item string) bool {
-	defer func() {
-		_ = recover();
-	}()
-
 	for _, v := range slice {
 		if v == item {
 			return true
@@ -35,27 +30,6 @@ func Contains(slice []string, item string) bool {
 	}
 
 	return false
-}
-
-func InterfaceToMap(i interface{}) map[string]string {
-	defer func() {
-		_ = recover();
-	}()
-
-	v := reflect.ValueOf(i)
-	output := make(map[string]string)
-
-	if i == nil {
-		return output
-	}
-
-	for _, key := range v.MapKeys() {
-		ckey := fmt.Sprintf("%v", key.Interface())
-		cvalue := fmt.Sprintf("%v", v.MapIndex(key).Interface())
-		output[ckey] = cvalue
-	}
-
-	return output
 }
 
 func WrapText(text string, width int) string {


### PR DESCRIPTION
## Highlights

- Fixes the 30k–35k request cliff ([GitHub issue](https://github.com/Alexis-Bize/InfiniteMITM/issues/21)): HTTP bodies were read but never closed, leaking TCP sockets until ephemeral ports exhausted — explains why cached reads kept working while writes (metadata saves) silently failed.
- Fixes UI lag on parallel-request bursts: buffered dispatcher between event listeners and bubbletea (was a synchronous handoff to an unbuffered channel).
- Caps memory growth: network UI request/response maps are now FIFO-capped at 2000; response bodies are only buffered when actually needed.

## Bug fixes

- Close req.Body/resp.Body before replacing them (TCP leak)
- Removed unbounded sync.Map of per-key mutexes in SmartCache → 64-stripe FNV lock
- runCommands now passes []string end-to-end (used to shatter on paths with spaces)
- Auto-detect active darwin network service (was hardcoded to Wi-Fi)
- DownloadFile now has a 60s timeout (was unbounded http.Get)
- Nil guard in stopServer; empty-slice guard in updater
- Removed 100ms race-hack sleep + per-event goroutines in the network UI

## Performance

- Buffered UI dispatcher (4096 slots) decouples goproxy from the TUI render loop
- Dropped JSON + base64 roundtrip from event payloads (typed structs now pass directly)
- Hoisted hot-path regex out of pattern.ReplaceMatches
- Tuned upstream transport: MaxIdleConnsPerHost: 32, IdleConnTimeout: 90s, ResponseHeaderTimeout: 30s

## Cleanup

- Removed dead TLSConfig (incl. misleading InsecureSkipVerify: true) on the http.Server
- Removed defer recover() no-ops swallowing panics
- Write helpers now log errors instead of silently dropping them
- Dropped reflect-based header coercion (was already typed)